### PR TITLE
HTTPS + Proxy

### DIFF
--- a/t/TestServer.pm
+++ b/t/TestServer.pm
@@ -135,7 +135,7 @@ sub act_as_proxy {
     # that this is the case.
     #
     #   http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2
-    if ( $request_uri !~ m!^http://! ) {
+    if ( $request_uri !~ m!^https?://! ) {
         warn "ERROR - not fully qualified request_uri '$request_uri'";
         return;
     }

--- a/t/proxy-with-https.t
+++ b/t/proxy-with-https.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+use URI::Escape;
+
+use Test::More;
+use HTTP::Request;
+
+require 't/TestServer.pm';
+
+eval "require LWP::Protocol::https";
+if ($@) {
+    plan skip_all => "LWP::Protocol::https required";
+    exit 0;
+}
+
+plan tests => 5;
+
+my $s1          = TestServer->new(10249);
+$s1->{is_proxy} = 1;
+my $s1_url_root = $s1->started_ok("starting a test server");
+
+ok( $s1_url_root, "got $s1_url_root" );
+
+my %tests = (
+    "https://www.google.co.uk/images/srpr/logo4w.png" => 200,
+);
+
+use HTTP::Async;
+my $q = HTTP::Async->new;
+
+while ( my ( $url, $code ) = each %tests ) {
+
+    my $req = HTTP::Request->new( 'GET', $url );
+
+    my %opts = ( proxy_host => '127.0.0.1', proxy_port => 10249, );
+
+    my $id = $q->add_with_opts( $req, \%opts );
+
+    ok $id, "Added request to the queue - $url";
+
+    my $res = $q->wait_for_next_response;
+    is( $res->code, $code, "Got a '$code' response" )
+        || warn $res->as_string;
+
+    # check that the proxy header was found if this was a proxy request.
+    my $proxy_header = $res->header('WasProxied') || '';
+    is $proxy_header, 'yes', "check for proxy header 'yes'";
+}


### PR DESCRIPTION
This change is fairly specific to our squid set-up, so I'd understand if you didn't want to pull it.

That said, it's the only thing I could get working and I _did_ try getting squid to listen on HTTPS and continue using Net::HTTPS::NB through HTTP::Async, and it didn't work properly. Might be a flaw in Net::HTTPS::NB, might be that I'm just not smart enough :-)

If you do pull this change then hopefully the new code and the comment I added will at least give people an idea of how they can make things work, if anybody else ever comes across this same problem.
