### PR TITLE
Make add_with_opts throw error on invalid options.

### DIFF
--- a/lib/HTTP/Async.pm
+++ b/lib/HTTP/Async.pm
@@ -231,13 +231,20 @@ This method lets you add a single request to the queue with options that
 differ from the defaults. For example you might wish to set a longer timeout
 or to use a specific proxy. Returns the id of the request.
 
+The method croaks when passed an invalid option.
+
 =cut
 
 sub add_with_opts {
     my $self = shift;
     my $req  = shift;
     my $opts = shift;
-    my $id   = $self->_next_id;
+
+    for my $key (keys %{$opts}) {
+        croak "$key not valid for add_with_opts" unless $GET_SET_KEYS{$key};
+    }
+
+    my $id = $self->_next_id;
 
     push @{ $$self{to_send} }, [ $req, $id ];
     $self->{id_opts}{$id} = $opts;

--- a/t/invalid-options.t
+++ b/t/invalid-options.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Test::Fatal;
+
+use HTTP::Async;
+use HTTP::Request;
+
+{
+    like(
+        exception {
+            HTTP::Async->new(
+                proxy_addr => "localhost",
+                proxy_port => 12345,
+            )
+        },
+        qr/proxy_addr not valid/,
+        'new dies on invalid option.'
+    );
+}
+
+{
+    my $q = HTTP::Async->new;
+    my $r = HTTP::Request->new;
+
+    like(
+        exception {
+            $q->add_with_opts($r, {
+                proxy_addr => "localhost",
+                proxy_port => 12345,
+            })
+        },
+        qr/proxy_addr not valid/,
+        'add_with_opts dies on invalid option.'
+    );
+}
+
+1;
+


### PR DESCRIPTION
The new method throws an error when it receives an invalid option, but the add_with_opts method did not. This caught me out when I accidentally passed proxy_address and proxy_port rather than proxy_host and proxy_port to it. This resulted in it attempting to treat the host of my request as the proxy and hanging until the request timed out.