### PR TITLE
ssl_options passed into add_with_opts are not honoured

### DIFF
--- a/lib/HTTP/Async.pm
+++ b/lib/HTTP/Async.pm
@@ -834,6 +834,9 @@ sub _send_request {
         # Add SSL options, if any, to args
         my $ssl_options = $self->_get_opt('ssl_options');
         @args{ keys %$ssl_options } = values %$ssl_options if $ssl_options;
+
+		# Override global SSL options with request-specific ones, if any
+		@args{ keys %{$args{ssl_opts}} } = values %{$args{ssl_opts}} if $args{ssl_opts};
     }
     elsif($uri->scheme and $uri->scheme eq 'https' and $request_is_to_proxy) {
         # We are making an HTTPS request through an HTTP proxy such as squid.

--- a/lib/HTTP/Async.pm
+++ b/lib/HTTP/Async.pm
@@ -835,8 +835,8 @@ sub _send_request {
         my $ssl_options = $self->_get_opt('ssl_options');
         @args{ keys %$ssl_options } = values %$ssl_options if $ssl_options;
 
-		# Override global SSL options with request-specific ones, if any
-		@args{ keys %{$args{ssl_opts}} } = values %{$args{ssl_opts}} if $args{ssl_opts};
+        # Override global SSL options with request-specific ones, if any
+        @args{ keys %{$args{ssl_opts}} } = values %{$args{ssl_opts}} if $args{ssl_opts};
     }
     elsif($uri->scheme and $uri->scheme eq 'https' and $request_is_to_proxy) {
         # We are making an HTTPS request through an HTTP proxy such as squid.


### PR DESCRIPTION
In troubleshooting some issue with multiple https request with `SSL_verifycn_scheme` set to `http`, I noticed that only the global `ssl_options`were actually being passed into the `Net::HTTPS::NB` constructor.

The simply solution was to add the options stored in `$args{ssl_opts}` back into `%args` after the global `ssl_options` are added.

        # Add SSL options, if any, to args
        my $ssl_options = $self->_get_opt('ssl_options');
        @args{ keys %$ssl_options } = values %$ssl_options if $ssl_options;

        # Override global SSL options with request-specific ones, if any
        @args{ keys %{$args{ssl_opts}} } = values %{$args{ssl_opts}} if $args{ssl_opts};

This has allowed me to successfully make requests to multiple sites using hostname verification. Sample:

    #!/usr/bin/perl
    
    use HTTP::Async;
    use HTTP::Request::Common;
    $IO::Socket::SSL::DEBUG = 3;
    
    my $async = HTTP::Async->new(ssl_options => {SSL_verifycn_scheme => 'http'});
    $async->add_with_opts(GET('https://site1.example.com'), {ssl_options => {SSL_hostname => 'site1.example.com'}});
    $async->add_with_opts(GET('https://site2.example.com'), {ssl_options => {SSL_hostname => 'site2.example.com'}});
    
    while (my $response = $async->wait_for_next_response) {
        print STDOUT $response->request->url . "\n";
        print STDOUT $response->content . "\n";
        print STDOUT $response->code . "\n";
        print STDOUT $response->message . "\n\n";
    }